### PR TITLE
Remove unstable API usage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.0.3"
 authors = ["Joe Wilm <jdwilm@gmail.com>"]
 license = "MIT"
 description = "An extensible chatbot"
+documentation = "https://chatbot.rs/chatbot/"
+repository = "https://github.com/jwilm/chatbot"
+keywords = ["chat", "bot", "extensible"]
+readme = "README.md"
 
 [[bin]]
 doc = false
@@ -12,7 +16,6 @@ path = "src/main.rs"
 
 [dependencies]
 regex = "0.1.30"
-regex_macros = "*"
 hyper = "0.5.0"
 rustc-serialize = "0.3.14"
 slack = "0.6.0"

--- a/src/adapter/cli.rs
+++ b/src/adapter/cli.rs
@@ -34,11 +34,13 @@ impl ChatAdapter for CliAdapter {
     ///     may be horribly inefficient.
     fn process_events(&self) -> Receiver<IncomingMessage> {
         println!("CliAdapter: process_events");
-        // hmm.. there doesn't appear to be any way to select on stdin. Use a thread
-        // until a better solution presents itself.
-        let (tx_stdin, rx_stdin) = channel();
-        thread::Builder::new().name("Chatbot CLI Reader".to_owned()).spawn(move || {
 
+        let (tx_incoming, rx_incoming) = channel();
+        let (tx_outgoing, rx_outgoing) = channel();
+        let name = self.get_name().to_owned();
+
+        // Read from stdin and send messages to the main loop
+        thread::Builder::new().name("Chatbot CLI Reader".to_owned()).spawn(move || {
             loop {
                 let mut line = String::new();
                 match io::stdin().read_line(&mut line) {
@@ -46,7 +48,9 @@ impl ChatAdapter for CliAdapter {
                         if len == 0 {
                             break;
                         }
-                        tx_stdin.send(line).unwrap();
+                        let msg = IncomingMessage::new(name.to_owned(), None, None, None, line,
+                            tx_outgoing.to_owned());
+                        tx_incoming.send(msg).unwrap();
                     },
                     Err(e) => {
                         println!("{:?}", e);
@@ -58,30 +62,18 @@ impl ChatAdapter for CliAdapter {
             println!("CliAdapter: shutting down");
         }).ok().expect("failed to create stdio reader");
 
-        let (tx_incoming, rx_incoming) = channel();
-        let (tx_outgoing, rx_outgoing) = channel();
-        let name = self.get_name().to_owned();
-
+        // process messages from the main loop
         thread::Builder::new().name("Chatbot CLI".to_owned()).spawn(move || {
             loop {
-                select!(
-                    adapter_msg = rx_outgoing.recv() => {
-                        match adapter_msg.unwrap() {
-                            AdapterMsg::Outgoing(msg) => {
-                                io::stdout().write(msg.as_bytes()).unwrap();
-                                io::stdout().write(b"\n").unwrap();
-                                io::stdout().flush().unwrap();
-                            },
-                            _ => break
-                        }
+                // TODO don't blindly unwrap
+                match rx_outgoing.recv().unwrap() {
+                    AdapterMsg::Outgoing(msg) => {
+                        io::stdout().write(msg.as_bytes()).unwrap();
+                        io::stdout().write(b"\n").unwrap();
+                        io::stdout().flush().unwrap();
                     },
-                    cli_result = rx_stdin.recv() => {
-                        let bytes = cli_result.unwrap();
-                        let msg = IncomingMessage::new(name.to_owned(), None, None, None, bytes,
-                            tx_outgoing.to_owned());
-                        tx_incoming.send(msg).unwrap();
-                    }
-                )
+                    _ => break
+                }
             }
         }).ok().expect("failed to create stdio <-> chatbot proxy");
 

--- a/src/handler/githubissue.rs
+++ b/src/handler/githubissue.rs
@@ -1,9 +1,12 @@
+extern crate regex;
+
 use std::io::Read;
 
 use hyper::Client;
 use hyper::header::UserAgent;
 use hyper::status::StatusCode;
 use regex::Captures;
+use regex::Regex;
 use rustc_serialize::json::Json;
 
 use handler::MessageHandler;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(std_misc)]
 #![deny(unused_must_use)]
 
 //!
@@ -47,12 +46,14 @@
 //! ```
 //!
 
-#![feature(plugin)]
-#![plugin(regex_macros)]
 extern crate regex;
 extern crate hyper;
 extern crate rustc_serialize;
 extern crate slack;
+
+macro_rules! regex(
+    ($s:expr) => (regex::Regex::new($s).unwrap());
+);
 
 pub mod chatbot;
 pub mod adapter;


### PR DESCRIPTION
This will enable publishing the project on crates.io and hopefully make it easier to get some community support. The `Select` usage in cli adapter was easily replaceable using the `select!` macro. The usage in `Chatbot` is not so easily replaced since it was selecting on an arbitrary number of service adapters. For now, a 1 adapter limit is being enforced until a solution is implemented which doesn't rely on unstable APIs.

Resolves #2.
