### PR TITLE
Clean up slack adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,31 +38,15 @@ fn main() {
 
 ## Plans
 
-My immediate priority list looks something like the following.
-
-1. Clean up slack adapter implementation
-2. Add a `RobotBrain` trait a `RedisBrain` implementation, and some sort of
-   structured text (json/toml/yaml? tbd). The brain will be passed into to the
-   handlers' `handle` method.
-3. Add more message handlers.
-    - GitHub issue poster
-    - countdowns
-    - simple key-value store for remembering things in chat
-4. [IRC Chat Adapter](https://github.com/jwilm/chatbot/issues/1)
-
-There are some other miscellaneous items in the [issue tracker][] as well.
-
-I can imagine a time when the handlers should get moved out into their own
-repository so their development can continue independently. The API needs to
-stabilize before that's possible.
+Check out the [issue tracker][] for an up-to-date list of plans for the chat
+bot.
 
 ## Contributing
 
 Contributions are very welcome on this project. To get started, fork the repo
-and clone it locally. You should be able to just do `cargo run` (assuming you're
-on the nightlies) and get a working echo handler on the command line. If you
-want to run the test program using the Slack adapter, do
-`cargo run -- --adapter slack`.
+and clone it locally. You should be able to just do `cargo run` and get a
+working ping and github handler on the command line. If you want to run the test
+program using the Slack adapter, do `cargo run -- --adapter slack`.
 
 [service adapters]: http://chatbot.rs/chatbot/adapter/trait.ChatAdapter.html#implementors
 [message handlers]: http://chatbot.rs/chatbot/handler/trait.MessageHandler.html#implementors

--- a/src/adapter/slack.rs
+++ b/src/adapter/slack.rs
@@ -9,6 +9,10 @@ use std::thread;
 
 use rustc_serialize::json::Json;
 use rustc_serialize::json;
+use rustc_serialize::json::DecoderError::MissingFieldError;
+use rustc_serialize::Decodable;
+use rustc_serialize::Decoder;
+
 use slack::Message;
 
 use message::AdapterMsg;
@@ -32,34 +36,109 @@ struct MyHandler {
   tx_adapter: Sender<AdapterMsg>
 }
 
+/// Data for a SlackMsg::Message
+#[allow(dead_code)]
+struct MessageData {
+    text: String,
+    channel: String,
+    user: String,
+    ts: String,
+    team: String
+}
+
+macro_rules! str_accessor {
+    ($s:ident) => {
+        pub fn $s(&self) -> &str {
+            self.$s.as_ref()
+        }
+    }
+}
+
+#[allow(dead_code)]
+impl MessageData {
+    str_accessor!(text);
+    str_accessor!(channel);
+    str_accessor!(user);
+    str_accessor!(ts);
+    str_accessor!(team);
+}
+
+/// Incoming slack messages on the websocket api
+enum SlackMsg {
+    /// A message was sent to a channel
+    Message(MessageData),
+
+    /// Some other type of message arrived.
+    /// [The list](https://api.slack.com/rtm) is quite extensive, and only the
+    /// messages the adapter is concerned with are enumerated here.
+    Other
+}
+
+impl Decodable for SlackMsg {
+    fn decode<D: Decoder>(d: &mut D) -> Result<SlackMsg, D::Error> {
+        d.read_struct("root", 0, |root| {
+            let msg_type = try!(root.read_struct_field("type", 0, |f| f.read_str() ));
+
+            match msg_type.as_ref() {
+                "message" => {
+                    Ok(SlackMsg::Message(MessageData {
+                        text: try!(root.read_struct_field("text", 0, |f| f.read_str())),
+                        channel: try!(root.read_struct_field("channel", 0, |f| f.read_str())),
+                        user: try!(root.read_struct_field("user", 0, |f| f.read_str())),
+                        ts: try!(root.read_struct_field("ts", 0, |f| f.read_str())),
+                        team: try!(root.read_struct_field("team", 0, |f| f.read_str())),
+                    }))
+                },
+                _ => {
+                    Ok(SlackMsg::Other)
+                }
+            }
+        })
+    }
+}
+
+fn string_to_slack_msg(raw: &str) -> Result<SlackMsg, json::DecoderError> {
+    // Some messages arriving from the slack client don't have a type. So far I've only
+    // witnessed confirmation messages arriving in this fashion. Since they go through the same
+    // pipeline as content messages, the decoder should be able to handle them.
+    match json::decode::<SlackMsg>(raw) {
+        Ok(value) => Ok(value),
+        Err(e) => {
+            match e {
+                MissingFieldError(field) => {
+                    match field.as_ref() {
+                        "type" => Ok(SlackMsg::Other),
+                        _ => Err(MissingFieldError(field))
+                    }
+                },
+                _ => Err(e)
+            }
+        }
+    }
+}
+
 #[allow(unused_variables)]
 impl slack::MessageHandler for MyHandler {
-    fn on_receive(&mut self, cli: &mut slack::RtmClient, json_str: &str) {
-        println!("Received[{}]: {}", self.count, json_str.to_string());
+    fn on_receive(&mut self, cli: &mut slack::RtmClient, raw: &str) {
+        println!("Received[{}]: {}", self.count, raw.to_string());
         self.count = self.count + 1;
-        let json_thing = Json::from_str(json_str).unwrap();
-        let json = json_thing.as_object().unwrap();
 
-        let msg_type = match json.get("type") {
-            Some(json_str) => json_str.as_string().unwrap(),
-            None => return
-        };
+        match string_to_slack_msg(raw) {
+            Ok(slack_msg) => {
+                match slack_msg {
+                    SlackMsg::Message(msg) => {
+                        let incoming = IncomingMessage::new("SlackAdapter".to_owned(), None,
+                            Some(msg.channel().to_owned()), Some(msg.user().to_owned()),
+                            msg.text().to_owned(), self.tx_adapter.clone());
 
-        match msg_type.as_ref() {
-            "message" => {
-                // TODO custom types for incoming messages.. unwrapunwrapunwrapunwrap
-                let channel = json.get("channel").unwrap().as_string().unwrap();
-                let user = json.get("user").unwrap().as_string().unwrap();
-                let payload = json.get("text").unwrap().as_string().unwrap();
-
-                let msg = IncomingMessage::new("SlackAdapter".to_owned(), None,
-                    Some(channel.to_owned()), Some(user.to_owned()), payload.to_owned(),
-                    self.tx_adapter.clone());
-
-                self.tx_bot.send(msg).unwrap();
+                        self.tx_bot.send(incoming).ok().expect("Bot unable to process messages");
+                    },
+                    _ => ()
+                }
             },
-            _ => {
-                return ();
+            Err(e) => {
+                println!("error decoding slack message: {:?}", e);
+                println!("please consider reporting this to jwilm/chatbot as it is probably a bug");
             }
         }
     }
@@ -138,3 +217,50 @@ impl ChatAdapter for SlackAdapter {
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use adapter::slack::SlackMsg;
+    use adapter::slack::string_to_slack_msg;
+
+    #[test]
+    fn decode_message() {
+        let raw = "{\"type\":\"message\", \
+                    \"channel\":\"D04UYUAMW\", \
+                    \"user\":\"U02ALMR84\", \
+                    \"text\":\"ping\", \
+                    \"ts\":\"1432563914.000007\", \
+                    \"team\":\"T02ALMR82\"}";
+
+        let slack_msg = string_to_slack_msg(raw).unwrap();
+
+        match slack_msg {
+            SlackMsg::Message(data) => {
+                assert_eq!(data.text(), "ping");
+                assert_eq!(data.channel(), "D04UYUAMW");
+                assert_eq!(data.user(), "U02ALMR84");
+                assert_eq!(data.ts(), "1432563914.000007");
+                assert_eq!(data.team(), "T02ALMR82");
+            },
+            _ => panic!("Expected SlackMsg::Message")
+        }
+    }
+    #[test]
+    fn decode_confirmation_message() {
+        let raw = r#"{"ok":true,"reply_to":0,"ts":"1432566639.000014","text":"pong"}"#;
+
+        match string_to_slack_msg(raw).unwrap() {
+            SlackMsg::Other => (),
+            _ => panic!("expected SlackMsg::Other")
+        }
+    }
+
+    #[test]
+    fn decode_unexpected_type() {
+        let raw = r#"{"type":"not_a_slack_msg_type"}"#;
+
+        match string_to_slack_msg(raw).unwrap() {
+            SlackMsg::Other => (),
+            _ => panic!("expected SlackMsg::Other")
+        }
+    }
+}

--- a/src/adapter/slack.rs
+++ b/src/adapter/slack.rs
@@ -142,9 +142,7 @@ impl OutgoingSlackMsg {
     fn new(id: i64, m: OutgoingMessage) -> OutgoingSlackMsg {
         OutgoingSlackMsg {
             id: id,
-            channel: m.get_incoming()
-                      .channel()
-                      .expect("missing channel").to_owned(),
+            channel: m.get_incoming().channel().expect("missing channel").to_owned(),
             msg_type: "message".to_owned(),
             text: m.as_ref().to_owned() // TODO move instead of copy
         }

--- a/src/adapter/slack.rs
+++ b/src/adapter/slack.rs
@@ -104,6 +104,11 @@ impl Decodable for SlackMsg {
     }
 }
 
+/// Convert a JSON string to a SlackMsg
+///
+/// This methods provides additional error handling around json::decode for certain errors
+/// that cannot be handled in the Decodable implementation. Specifically, MissingFieldError
+/// where the field is "type" are actually valid messages despite missing the "type" field.
 fn string_to_slack_msg(raw: &str) -> Result<SlackMsg, json::DecoderError> {
     // Some messages arriving from the slack client don't have a type. So far I've only
     // witnessed confirmation messages arriving in this fashion. Since they go through the same

--- a/src/adapter/slack/mod.rs
+++ b/src/adapter/slack/mod.rs
@@ -1,0 +1,123 @@
+extern crate slack;
+
+mod message;
+use self::message::*;
+
+use std::env;
+use std::sync::atomic::{AtomicIsize, Ordering};
+use std::sync::mpsc::Sender;
+use std::sync::mpsc::Receiver;
+use std::sync::mpsc::channel;
+use std::thread;
+
+use rustc_serialize::json::ToJson;
+
+use slack::Message;
+
+use adapter::ChatAdapter;
+use message::AdapterMsg;
+use message::IncomingMessage;
+
+/// SlackAdapter sends and receives messages from the Slack chat service. Until actualy
+/// configuration is added, the slack token should be placed in the environment variable
+/// `SLACK_BOT_TOKEN`
+pub struct SlackAdapter {
+    token: String
+}
+
+impl SlackAdapter {
+    pub fn new() -> SlackAdapter {
+        SlackAdapter {
+            token: match env::var("SLACK_BOT_TOKEN") {
+                Ok(t) => t,
+                Err(_) => panic!("Failed to get SLACK_BOT_TOKEN from env")
+            }
+        }
+    }
+}
+
+struct MyHandler {
+  count: i64,
+  tx_bot: Sender<IncomingMessage>,
+  tx_adapter: Sender<AdapterMsg>
+}
+
+#[allow(unused_variables)]
+impl slack::MessageHandler for MyHandler {
+    fn on_receive(&mut self, cli: &mut slack::RtmClient, raw: &str) {
+        println!("Received[{}]: {}", self.count, raw.to_string());
+        self.count = self.count + 1;
+
+        match string_to_slack_msg(raw) {
+            Ok(slack_msg) => {
+                match slack_msg {
+                    Event::Message(Msg::Plain(msg)) => {
+                        let incoming = IncomingMessage::new("SlackAdapter".to_owned(), None,
+                            Some(msg.channel().to_owned()), Some(msg.user().to_owned()),
+                            msg.text().to_owned(), self.tx_adapter.clone());
+
+                        self.tx_bot.send(incoming).ok().expect("Bot unable to process messages");
+                    },
+                    _ => ()
+                }
+            },
+            Err(e) => {
+                println!("error decoding slack message: {:?}", e);
+                println!("please consider reporting this to jwilm/chatbot as it is probably a bug");
+            }
+        }
+    }
+
+    fn on_ping(&mut self, cli: &mut slack::RtmClient) { }
+
+    fn on_close(&mut self, cli: &mut slack::RtmClient) { }
+
+    fn on_connect(&mut self, cli: &mut slack::RtmClient) { }
+}
+
+impl ChatAdapter for SlackAdapter {
+    /// SlackAdapter name
+    fn get_name(&self) -> &str {
+        "SlackAdapter"
+    }
+
+    fn process_events(&self) -> Receiver<IncomingMessage> {
+        println!("SlackAdapter: process_events");
+        let (tx_bot, rx_bot) = channel();
+        let (tx_adapter, rx_adapter) = channel();
+
+        let uid = AtomicIsize::new(0);
+
+        let mut cli = slack::RtmClient::new();
+        let (client, slack_rx) = cli.login(self.token.as_ref()).unwrap();
+        let slack_tx = cli.get_outs().unwrap();
+
+        thread::Builder::new().name("Chatbot Slack Receiver".to_owned()).spawn(move || {
+            let mut handler = MyHandler{count: 0, tx_bot: tx_bot, tx_adapter: tx_adapter};
+            cli.run::<MyHandler>(&mut handler, client, slack_rx).unwrap();
+        }).ok().expect("failed to create thread for slack receiver");
+
+        thread::Builder::new().name("Chatbot Slack Sender".to_owned()).spawn(move || {
+            loop {
+                match rx_adapter.recv() {
+                    Ok(msg) => {
+                        match msg {
+                            AdapterMsg::Outgoing(m) => {
+                                let id = uid.fetch_add(1, Ordering::SeqCst) as i64;
+                                let out = OutgoingEvent::new(id, m);
+                                slack_tx.send(Message::Text(out.to_json().to_string())).unwrap();
+                            }
+                            _ => unreachable!("No other messages being sent yet")
+                        }
+                    },
+                    Err(e) => {
+                        println!("error receiving outgoing messages: {}", e);
+                        break
+                    }
+                }
+            }
+        }).ok().expect("failed to create thread for slack sender");
+
+        rx_bot
+    }
+}


### PR DESCRIPTION
The initial slack adapter implementation did not handle errors well. These changes add a SlackMsg type which implements the Decodable trait.
