### PR TITLE
Add support (again) for concurrent adapters

### DIFF
--- a/src/adapter/cli.rs
+++ b/src/adapter/cli.rs
@@ -1,4 +1,4 @@
-use std::sync::mpsc::Receiver;
+use std::sync::mpsc::Sender;
 use std::sync::mpsc::channel;
 use std::thread;
 use std::io;
@@ -32,10 +32,9 @@ impl ChatAdapter for CliAdapter {
     /// 1.  receive input from stdin and
     /// 2.  listen for messages coming from the main thread. This implementation
     ///     may be horribly inefficient.
-    fn process_events(&self) -> Receiver<IncomingMessage> {
+    fn process_events(&self, tx_incoming: Sender<IncomingMessage>) {
         println!("CliAdapter: process_events");
 
-        let (tx_incoming, rx_incoming) = channel();
         let (tx_outgoing, rx_outgoing) = channel();
         let name = self.get_name().to_owned();
 
@@ -77,7 +76,6 @@ impl ChatAdapter for CliAdapter {
             }
         }).ok().expect("failed to create stdio <-> chatbot proxy");
 
-        rx_incoming
     }
 }
 

--- a/src/adapter/mod.rs
+++ b/src/adapter/mod.rs
@@ -1,4 +1,4 @@
-use std::sync::mpsc::Receiver;
+use std::sync::mpsc::Sender;
 
 use message::IncomingMessage;
 
@@ -16,8 +16,10 @@ pub trait ChatAdapter {
     fn get_name(&self) -> &str;
 
     /// ChatAdapters must implement process_events. What this method does will
-    /// vary wildly by adapter. At the very least, it must return a receiver
-    /// which the main loop will `recv` on to get messages from the adapter.
-    fn process_events(&self) -> Receiver<IncomingMessage>;
+    /// vary wildly by adapter. At the very least, it must generate IncominMessages from its input,
+    /// send them via the `Sender` that's passed in. The main loop has the other end of this
+    /// receiver. The IncomingMessage must be constructed with a `Sender<OutgoingMessage>` for
+    /// which the adapter listens on the Receiver to send messages back to the service.
+    fn process_events(&self, Sender<IncomingMessage>);
 }
 


### PR DESCRIPTION
The original implementation of concurrent adapters relied on
std::sync::mpsc::Select which is unstable and unsafe. Since chatbot
needed to be released on the stable line, using Select was not an
option. The adapter interface was refactored slightly to accept a sender
instead of returning a receiver. The channel is now created by the main
thread, and transmitters for IncomingMessage are included in the adapter
`process_events` call. This allows the receiver in the main thread to
receive messages from all of the adapters.

Resolves #13.
