### PR TITLE
Filtered handlers

### DIFF
--- a/src/chatbot.rs
+++ b/src/chatbot.rs
@@ -1,3 +1,4 @@
+use regex::Regex;
 use std::sync::mpsc::channel;
 
 use adapter::ChatAdapter;
@@ -10,7 +11,8 @@ use handler::MessageHandler;
 pub struct Chatbot {
     name: String,
     adapters: Vec<Box<ChatAdapter>>,
-    handlers: Vec<Box<MessageHandler>>
+    handlers: Vec<Box<MessageHandler>>,
+    addresser: Option<Regex>
 }
 
 impl Chatbot {
@@ -23,7 +25,8 @@ impl Chatbot {
         Chatbot {
             name: name.to_owned(),
             adapters: Vec::new(),
-            handlers: Vec::new()
+            handlers: Vec::new(),
+            addresser: None
         }
     }
 

--- a/src/chatbot.rs
+++ b/src/chatbot.rs
@@ -100,6 +100,12 @@ impl Chatbot {
                 let msg_str = msg.get_contents();
 
                 if handler.can_handle(msg_str) {
+                    if let Some(ref addresser) = self.addresser {
+                      if !addresser.is_match(msg_str) {
+                        continue;
+                      }
+                    }
+
                     match handler.handle(&msg) {
                         Err(e) => {
                             println!("Error in handler `{}`", handler.name());

--- a/src/chatbot.rs
+++ b/src/chatbot.rs
@@ -38,9 +38,9 @@ impl Chatbot {
         self.name.as_ref()
     }
 
-    /// Return the regular expression of what the bot will be addressed by, if present
-    pub fn get_addresser(&self) -> Option<&Regex> {
-        self.addresser.as_ref()
+    /// Return the regular expression of what the bot will be addressed by
+    pub fn get_addresser(&self) -> &Regex {
+        &self.addresser
     }
 
     /// Add a ChatAdapter to the bot

--- a/src/chatbot.rs
+++ b/src/chatbot.rs
@@ -105,9 +105,9 @@ impl Chatbot {
                     // When addresser is present, ignore handlers that don't directly call the
                     // bot's name
                     if let Some(ref addresser) = self.addresser {
-                      if !addresser.is_match(msg_str) {
-                        continue;
-                      }
+                        if !addresser.is_match(msg_str) {
+                            continue;
+                        }
                     }
 
                     match handler.handle(&msg) {

--- a/src/chatbot.rs
+++ b/src/chatbot.rs
@@ -12,7 +12,7 @@ pub struct Chatbot {
     name: String,
     adapters: Vec<Box<ChatAdapter>>,
     handlers: Vec<Box<MessageHandler>>,
-    addresser: Option<Regex>
+    addresser: Regex
 }
 
 impl Chatbot {
@@ -22,11 +22,14 @@ impl Chatbot {
     /// want. You'll want to make your binding mutable so you can call `add_adapter` and
     /// `add_handler`.
     pub fn new(name: &str) -> Chatbot {
+        let addresser_str = format!(r"^\s*@?{}[:,\s]\s*", name);
+        let addresser = Regex::new(addresser_str.as_ref());
+
         Chatbot {
             name: name.to_owned(),
             adapters: Vec::new(),
             handlers: Vec::new(),
-            addresser: None
+            addresser: addresser.unwrap()
         }
     }
 

--- a/src/chatbot.rs
+++ b/src/chatbot.rs
@@ -69,6 +69,7 @@ impl Chatbot {
         self.handlers.push(Box::new(handler))
     }
 
+    /// Add a MessageHandler, that requires the bot to be addressed, to the bot
     pub fn add_addressed_handler<T>(&mut self, handler: T)
         where T: MessageHandler + 'static
     {

--- a/src/chatbot.rs
+++ b/src/chatbot.rs
@@ -97,12 +97,14 @@ impl Chatbot {
 
             // Distribute to handlers
             for handler in &self.handlers {
-                if handler.can_handle(msg.get_contents()) {
+                let msg_str = msg.get_contents();
+
+                if handler.can_handle(msg_str) {
                     match handler.handle(&msg) {
                         Err(e) => {
                             println!("Error in handler `{}`", handler.name());
                             println!("{:?}", e);
-                            println!("The incoming message was {}", msg.get_contents());
+                            println!("The incoming message was {}", msg_str);
 
                             // TODO remove handler?
                         },

--- a/src/chatbot.rs
+++ b/src/chatbot.rs
@@ -12,6 +12,7 @@ pub struct Chatbot {
     name: String,
     adapters: Vec<Box<ChatAdapter>>,
     handlers: Vec<Box<MessageHandler>>,
+    addressed_handlers: Vec<Box<MessageHandler>>,
     addresser: Regex
 }
 
@@ -29,6 +30,7 @@ impl Chatbot {
             name: name.to_owned(),
             adapters: Vec::new(),
             handlers: Vec::new(),
+            addressed_handlers: Vec::new(),
             addresser: addresser.unwrap()
         }
     }
@@ -65,6 +67,13 @@ impl Chatbot {
     {
         println!("Adding handler {}", handler.name());
         self.handlers.push(Box::new(handler))
+    }
+
+    pub fn add_addressed_handler<T>(&mut self, handler: T)
+        where T: MessageHandler + 'static
+    {
+        println!("Adding handler {}", handler.name());
+        self.addressed_handlers.push(Box::new(handler))
     }
 
     /// Start processing messages

--- a/src/chatbot.rs
+++ b/src/chatbot.rs
@@ -158,16 +158,9 @@ mod tests {
     }
 
     #[test]
-    fn test_chatbot_address_by_name() {
-        let mut bot = Chatbot::new("testbot");
-        bot.address_by_name();
-    }
-
-    #[test]
     fn test_chatbot_address_matches() {
-        let mut bot = Chatbot::new("testbot");
-        bot.address_by_name();
-        let addresser = bot.get_addresser().unwrap();
+        let bot = Chatbot::new("testbot");
+        let addresser = bot.get_addresser();
 
         assert!(!addresser.is_match("testbotping"),
                 "Shouldn't match bot name without a break (space, colon, comma)");

--- a/src/chatbot.rs
+++ b/src/chatbot.rs
@@ -151,4 +151,43 @@ mod tests {
         });
         bot.add_handler(echo);
     }
+
+    #[test]
+    fn test_chatbot_address_by_name() {
+        let mut bot = Chatbot::new("testbot");
+        bot.address_by_name();
+    }
+
+    #[test]
+    fn test_chatbot_address_matches() {
+        let mut bot = Chatbot::new("testbot");
+        bot.address_by_name();
+        let addresser = bot.get_addresser().unwrap();
+
+        assert!(!addresser.is_match("testbotping"),
+                "Shouldn't match bot name without a break (space, colon, comma)");
+        assert!(!addresser.is_match("@testbotping"),
+                "Shouldn't match bot name with '@' sign minus a break (space, colon, comma)");
+
+        // Space separation
+        assert!(addresser.is_match("testbot ping"), "Should match bot name with space");
+        assert!(addresser.is_match("@testbot ping"),
+                "Should match bot name with '@' sign plus '@' space");
+
+        // Colon separation
+        assert!(addresser.is_match("testbot:ping"), "Should match bot name with colon");
+        assert!(addresser.is_match("testbot: ping"), "Should match bot name with colon and space");
+        assert!(addresser.is_match("@testbot:ping"),
+                "Should match bot name with '@' sign plus colon");
+        assert!(addresser.is_match("@testbot: ping"),
+                "Should match bot name with '@' sign plus colon and space");
+
+        // Comma separation
+        assert!(addresser.is_match("testbot,ping"), "Should match bot name with comma");
+        assert!(addresser.is_match("testbot, ping"), "Should match bot name with comma and space");
+        assert!(addresser.is_match("@testbot,ping"),
+                "Should match bot name with '@' sign plus comma");
+        assert!(addresser.is_match("@testbot, ping"),
+                "Should match bot name with '@' sign plus comma and space");
+    }
 }

--- a/src/chatbot.rs
+++ b/src/chatbot.rs
@@ -35,6 +35,17 @@ impl Chatbot {
         self.name.as_ref()
     }
 
+    pub fn get_addresser(&self) -> Option<&Regex> {
+        self.addresser.as_ref()
+    }
+
+    pub fn address_by_name(&mut self) {
+        let addresser_str = format!(r"^\s*@?{}[:,\s]\s*", self.get_name());
+        let addresser = Regex::new(addresser_str.as_ref());
+
+        self.addresser = addresser.ok();
+    }
+
     /// Add a ChatAdapter to the bot
     ///
     /// Add as many adapters as you like. The IncomingMessages sent by adapters are made available

--- a/src/chatbot.rs
+++ b/src/chatbot.rs
@@ -43,14 +43,6 @@ impl Chatbot {
         self.addresser.as_ref()
     }
 
-    /// Turns on the requirement of addressing the bot before a handler is triggered
-    pub fn address_by_name(&mut self) {
-        let addresser_str = format!(r"^\s*@?{}[:,\s]\s*", self.get_name());
-        let addresser = Regex::new(addresser_str.as_ref());
-
-        self.addresser = addresser.ok();
-    }
-
     /// Add a ChatAdapter to the bot
     ///
     /// Add as many adapters as you like. The IncomingMessages sent by adapters are made available

--- a/src/chatbot.rs
+++ b/src/chatbot.rs
@@ -35,10 +35,12 @@ impl Chatbot {
         self.name.as_ref()
     }
 
+    /// Return the regular expression of what the bot will be addressed by, if present
     pub fn get_addresser(&self) -> Option<&Regex> {
         self.addresser.as_ref()
     }
 
+    /// Turns on the requirement of addressing the bot before a handler is triggered
     pub fn address_by_name(&mut self) {
         let addresser_str = format!(r"^\s*@?{}[:,\s]\s*", self.get_name());
         let addresser = Regex::new(addresser_str.as_ref());
@@ -100,6 +102,8 @@ impl Chatbot {
                 let msg_str = msg.get_contents();
 
                 if handler.can_handle(msg_str) {
+                    // When addresser is present, ignore handlers that don't directly call the
+                    // bot's name
                     if let Some(ref addresser) = self.addresser {
                       if !addresser.is_match(msg_str) {
                         continue;

--- a/src/chatbot.rs
+++ b/src/chatbot.rs
@@ -100,20 +100,17 @@ impl Chatbot {
                 Ok(msg) => msg,
                 Err(_) => break
             };
+            let msg_str = msg.get_contents();
+
+            let handlers = if self.addresser.is_match(msg_str) {
+                &self.addressed_handlers
+            } else {
+                &self.handlers
+            };
 
             // Distribute to handlers
-            for handler in &self.handlers {
-                let msg_str = msg.get_contents();
-
+            for handler in handlers {
                 if handler.can_handle(msg_str) {
-                    // When addresser is present, ignore handlers that don't directly call the
-                    // bot's name
-                    if let Some(ref addresser) = self.addresser {
-                        if !addresser.is_match(msg_str) {
-                            continue;
-                        }
-                    }
-
                     match handler.handle(&msg) {
                         Err(e) => {
                             println!("Error in handler `{}`", handler.name());


### PR DESCRIPTION
Added support for filtering handlers #6 via requiring chatbot be addressed when `Chatbot::address_by_name` is called.

The test `test_chatbot_address_matches` shows the ways different ways chatbot can and can't be addressed.
