### PR TITLE
Documentation for Addressed Handlers

### DIFF
--- a/examples/cli_ping.rs
+++ b/examples/cli_ping.rs
@@ -1,0 +1,16 @@
+#[macro_use(handler)]
+extern crate chatbot;
+
+use chatbot::Chatbot;
+use chatbot::adapter::CliAdapter;
+
+fn main() {
+    let mut bot = Chatbot::new("pingbot");
+
+    let ping = handler!("PingHandler", r"ping", |_, _| Some("pong".to_owned()));
+
+    bot.add_addressed_handler(ping);
+    bot.add_adapter(CliAdapter::new());
+
+    bot.run();
+}

--- a/src/chatbot.rs
+++ b/src/chatbot.rs
@@ -104,7 +104,7 @@ impl Chatbot {
     pub fn run(&self) {
 
         assert!(self.adapters.len() > 0);
-        assert!(self.handlers.len() > 0);
+        assert!(self.handlers.len() > 0 || self.addressed_handlers.len() > 0);
 
         println!("Chatbot: {} adapters", self.adapters.len());
         println!("Chatbot: {} handlers", self.handlers.len());

--- a/src/chatbot.rs
+++ b/src/chatbot.rs
@@ -102,12 +102,14 @@ impl Chatbot {
     /// Call process_events on all of the adapters and `recv` on the `IncomingMessage` channel.
     /// Distribute IncomingMessages to list of handlers.
     pub fn run(&self) {
+        let adapters_len = self.adapters.len();
+        let handlers_len = self.handlers.len() + self.addressed_handlers.len();
 
-        assert!(self.adapters.len() > 0);
-        assert!(self.handlers.len() > 0 || self.addressed_handlers.len() > 0);
+        assert!(adapters_len > 0);
+        assert!(handlers_len > 0);
 
-        println!("Chatbot: {} adapters", self.adapters.len());
-        println!("Chatbot: {} handlers", self.handlers.len());
+        println!("Chatbot: {} adapters", adapters_len);
+        println!("Chatbot: {} handlers", handlers_len);
 
         let (incoming_tx, incoming_rx) = channel();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,6 +73,31 @@
 //! # }
 //! ```
 //!
+//! Sometimes you might want the bot to react only when it is addressed,
+//! this is what
+//! [`add_addressed_handler`](chatbot/struct.Chatbot.html#method.add_addressed_handler) is for.
+//!
+//! An example would be a bot that responses to pings, only you don't want the bot to respond
+//! everytime there is any form of "ping" in a sentence.
+//!
+//! ```no_run
+//! # #[macro_use(handler)]
+//! # extern crate chatbot;
+//! # fn main() {
+//! use chatbot::Chatbot;
+//! use chatbot::adapter::CliAdapter;
+//!
+//! let mut bot = Chatbot::new("pingbot");
+//!
+//! let ping = handler!("PingHandler", r"ping", |_, _| Some("pong".to_owned()));
+//!
+//! bot.add_addressed_handler(ping);
+//! bot.add_adapter(CliAdapter::new());
+//!
+//! bot.run();
+//! # }
+//! ```
+//!
 
 extern crate regex;
 extern crate hyper;

--- a/src/main.rs
+++ b/src/main.rs
@@ -79,7 +79,7 @@ fn main() {
     }
 
     bot.add_handler(ping);
-    bot.add_handler(trout);
+    bot.add_addressed_handler(trout);
     bot.add_handler(echo);
     bot.add_handler(GithubIssueLinker::new());
 


### PR DESCRIPTION
I added documentation and an example of addressed handlers in use. There was also a panic in `run` when there was only addressed handlers and no other global handlers that I fixed.
