### PR TITLE
Implement replying to irc messages in private

### DIFF
--- a/src/adapter/irc.rs
+++ b/src/adapter/irc.rs
@@ -111,6 +111,11 @@ impl ChatAdapter for IrcAdapter {
                                 };
 
                             }
+                            AdapterMsg::Private(m) => {
+                                let incoming = m.get_incoming();
+                                let user = incoming.user().unwrap();
+                                server.send_privmsg(user, m.as_ref()).unwrap()
+                            }
                             _ => unreachable!("No other messages being sent yet")
                         }
                     },

--- a/src/adapter/irc.rs
+++ b/src/adapter/irc.rs
@@ -116,7 +116,9 @@ impl ChatAdapter for IrcAdapter {
                                 let user = incoming.user().unwrap();
                                 server.send_privmsg(user, m.as_ref()).unwrap()
                             }
-                            _ => unreachable!("No other messages being sent yet")
+                            AdapterMsg::Shutdown => {
+                                break
+                            }
                         }
                     },
                     Err(e) => {

--- a/src/adapter/slack/mod.rs
+++ b/src/adapter/slack/mod.rs
@@ -115,7 +115,9 @@ impl ChatAdapter for SlackAdapter {
                             AdapterMsg::Private(_) => {
                                 println!("SlackAdaptor: Private messages not implemented");
                             }
-                            _ => unreachable!("No other messages being sent yet")
+                            AdapterMsg::Shutdown => {
+                                break
+                            }
                         }
                     },
                     Err(e) => {

--- a/src/adapter/slack/mod.rs
+++ b/src/adapter/slack/mod.rs
@@ -111,6 +111,10 @@ impl ChatAdapter for SlackAdapter {
                                 let out = OutgoingEvent::new(id, m);
                                 slack_tx.send(Message::Text(out.to_json().to_string())).unwrap();
                             }
+                            // Not implemented for now
+                            AdapterMsg::Private(_) => {
+                                println!("SlackAdaptor: Private messages not implemented");
+                            }
                             _ => unreachable!("No other messages being sent yet")
                         }
                     },

--- a/src/message.rs
+++ b/src/message.rs
@@ -16,6 +16,8 @@ use std::sync::mpsc::SendError;
 pub enum AdapterMsg {
     /// A message that should be sent to a chat provider
     Outgoing(OutgoingMessage),
+    /// A message that will be sent to the user in private
+    Private(OutgoingMessage),
     /// The chatbot is shutting down and the adapters should nicely terminate their connections.
     Shutdown
 }
@@ -102,6 +104,12 @@ impl IncomingMessage {
     pub fn reply(&self, msg: String) -> Result<(), SendError<AdapterMsg>> {
         let outgoing = OutgoingMessage::new(msg, self.to_owned());
         self.tx.send(AdapterMsg::Outgoing(outgoing))
+    }
+
+    /// Reply to a message in a private message
+    pub fn reply_private(&self, msg: String) -> Result<(), SendError<AdapterMsg>> {
+        let outgoing = OutgoingMessage::new(msg, self.to_owned());
+        self.tx.send(AdapterMsg::Private(outgoing))
     }
 }
 


### PR DESCRIPTION
Hi!

I'm writing an irc game that requires sharing some state with the user in private.

This probably can't be merged as is (unless you're ok with being slightly broken on master) since it'll crash slack. I wanted to see if you had feedback before I go work out how to make this work for the slack adaptor.
