### PR TITLE
Abort chatbot process if a worker thread panics

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ name = "chatbot"
 path = "src/main.rs"
 
 [dependencies]
+abort_on_panic = "1.0.0"
 regex = "~0.1"
 hyper = "~0.5"
 rustc-serialize = "~0.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,6 +99,8 @@
 //! ```
 //!
 
+#[macro_use]
+extern crate abort_on_panic;
 extern crate regex;
 extern crate hyper;
 extern crate rustc_serialize;


### PR DESCRIPTION
(Here's a solution for one of the two issues we were discussing. Thank you so much for maintaining chatbot and for helping figure this stuff out! -@emk)

The problem: Sometimes, one of chatbot's worker threads will panic.
This leaves chatbot in a weird state:
1. It can't perform all the tasks it was asked to perform, but
2. It still appears to be running, so no external process will realize
   that the chatbot needs to be restarted.

This patch address (2).  It was written with three constraints in mind:
1. It must work on stable Rust.
2. It must not prevent panic messages from being printed.
3. It must cause the entire chatbot to shut down if any part of the
   chatbot is broken beyond repair.

This doesn't fix jwilm/chatbot#17, but it should provide a brute-force
workaround to keep the chatbot running until a solution should be
found.  And it should protect against other unhandled panics in worker
threads using suspicious 3rd-party crates to talk to various services.

I used `git diff -b` to make sure that no unintended changes slipped in
while re-indenting the affected blocks.
