### PR TITLE
Update slack and irc dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,12 +13,8 @@ readme = "README.md"
 regex = "0.1"
 rustc-serialize = "0.3"
 getopts = "0.2"
-irc = { version = "0.11", optional = true }
-
-[dependencies.slack]
-git = "https://github.com/jwilm/slack-rs"
-rev = "a7390f2524a8e9e886f8b1be2d2a992261f5065b"
-optional = true
+irc = { version = "0.12", optional = true }
+slack = { version = "0.18.0", optional = true }
 
 [features]
 default = []

--- a/examples/bot.rs
+++ b/examples/bot.rs
@@ -28,7 +28,7 @@ fn main() {
 
     // Add adapter based on command line argument
     match adapter_name.as_ref() {
-        "slack" => bot.add_adapter(SlackAdapter::new()),
+        "slack" => bot.add_adapter(SlackAdapter::new(name)),
         "cli" => bot.add_adapter(CliAdapter::new(name)),
         "irc" => {
             let config = chatbot::adapter::IrcConfig {


### PR DESCRIPTION
This PR updates the `irc` crate to version 0.12 and the `slack` crate to version 0.18. It then changes the irc and slack adapter code to work with these new versions.

This also happens to fix #31 and the travis build.

